### PR TITLE
fixed import errors from next folder on all tsx files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
+    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"


### PR DESCRIPTION
Small change to fix errors happening when importing anything on a tsx file from "next".
Screenshot below shows an example of the error. By adding a `"moduleResolution": "Node"` to the tsconfig file, this is fixed.

<img width="764" alt="Screenshot 2022-07-27 at 14 09 59" src="https://user-images.githubusercontent.com/40884485/181243495-5c64633c-1785-40ae-9826-0512d9e50a2a.png">
